### PR TITLE
Better class aliasing for compatibility with MediaWiki

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -29,19 +29,26 @@ namespace MediaWiki\Extension\CrawlerProtection;
 // These need to be in global scope so phan can pick up on them,
 // and before any use statements that make use of the namespaced names.
 
-if ( version_compare( MW_VERSION, '1.41', '<' ) ) {
-	class_alias( '\OutputPage', '\MediaWiki\Output\OutputPage' );
-	class_alias( '\SpecialPage', '\MediaWiki\SpecialPage\SpecialPage' );
-	class_alias( '\User', '\MediaWiki\User\User' );
-	class_alias( '\WebRequest', '\MediaWiki\Request\WebRequest' );
+if ( class_exists( \Title::class ) && !class_exists( \MediaWiki\Title\Title::class ) ) {
+	class_alias( \Title::class, \MediaWiki\Title\Title::class ); /* < 1.40 */
 }
-
-if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
-	class_alias( '\MediaWiki', '\MediaWiki\Actions\ActionEntryPoint' );
+if ( class_exists( \OutputPage::class ) && !class_exists( \MediaWiki\Output\OutputPage::class ) ) {
+	class_alias( \OutputPage::class, \MediaWiki\Output\OutputPage::class ); /* < 1.41 */
 }
-
-if ( version_compare( MW_VERSION, '1.44', '<' ) ) {
-	class_alias( '\Article', '\MediaWiki\Page\Article' );
+if ( class_exists( \WebRequest::class ) && !class_exists( \MediaWiki\Request\WebRequest::class ) ) {
+	class_alias( \WebRequest::class, \MediaWiki\Request\WebRequest::class ); /* < 1.41 */
+}
+if ( class_exists( \SpecialPage::class ) && !class_exists( \MediaWiki\SpecialPage\SpecialPage::class ) ) {
+	class_alias( \SpecialPage::class, \MediaWiki\SpecialPage\SpecialPage::class ); /* < 1.41 */
+}
+if ( class_exists( \User::class ) && !class_exists( \MediaWiki\User\User::class ) ) {
+	class_alias( \User::class, \MediaWiki\User\User::class ); /* < 1.41 */
+}
+if ( class_exists( \ActionEntryPoint::class ) && !class_exists( \MediaWiki\Actions\ActionEntryPoint::class ) ) {
+	class_alias( \ActionEntryPoint::class, \MediaWiki\Actions\ActionEntryPoint::class ); /* < 1.42 */
+}
+if ( class_exists( \Article::class ) && !class_exists( \MediaWiki\Page\Article::class ) ) {
+	class_alias( \Article::class, \MediaWiki\Page\Article::class ); /* < 1.42 */
 }
 
 use MediaWiki\Actions\ActionEntryPoint;


### PR DESCRIPTION
I guess
class_alias( '\MediaWiki', '\MediaWiki\Actions\ActionEntryPoint' ) is a mistake, it should be
class_alias( '\ ActionEntryPoint', '\MediaWiki\Actions\ActionEntryPoint' )

And
if ( class_exists( \ClassName::class ) )
is a better and more secure choice to
if ( version_compare( MW_VERSION, '1.xy', '<' ) )