### PR TITLE
Skip protection in CLI/maintenance context

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "name": "CrawlerProtection",
     "author": "[https://mywikis.com MyWikis LLC]",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "url": "https://www.mediawiki.org/wiki/Extension:CrawlerProtection",
     "description": "Suite of protective measures to protect wikis from crawlers.",
     "type": "hook",

--- a/includes/CrawlerProtectionService.php
+++ b/includes/CrawlerProtectionService.php
@@ -36,6 +36,10 @@ use Wikimedia\IPUtils;
  *
  * Determines whether a given request should be blocked for anonymous
  * users and delegates the actual denial to ResponseFactory.
+ *
+ * Only web requests are subject to protection. On the command line there is
+ * no crawler to guard against, and denying access there aborts maintenance
+ * scripts that re-parse pages transcluding a protected special page.
  */
 class CrawlerProtectionService {
 
@@ -54,17 +58,23 @@ class CrawlerProtectionService {
 	/** @var ResponseFactory */
 	private ResponseFactory $responseFactory;
 
+	/** @var bool */
+	private bool $cliMode;
+
 	/**
 	 * @param ServiceOptions $options
 	 * @param ResponseFactory $responseFactory
+	 * @param bool $cliMode
 	 */
 	public function __construct(
 		ServiceOptions $options,
-		ResponseFactory $responseFactory
+		ResponseFactory $responseFactory,
+		bool $cliMode
 	) {
 		$options->assertRequiredOptions( self::CONSTRUCTOR_OPTIONS );
 		$this->options = $options;
 		$this->responseFactory = $responseFactory;
+		$this->cliMode = $cliMode;
 	}
 
 	/**
@@ -83,6 +93,10 @@ class CrawlerProtectionService {
 		$user,
 		$request
 	): bool {
+		if ( $this->cliMode ) {
+			return true;
+		}
+
 		if ( $user->isRegistered() || $this->isIPAllowed( $user->getName() ) ) {
 			return true;
 		}
@@ -186,6 +200,10 @@ class CrawlerProtectionService {
 		$output,
 		$user
 	): bool {
+		if ( $this->cliMode ) {
+			return true;
+		}
+
 		if ( $user->isRegistered() || $this->isIPAllowed( $user->getName() ) ) {
 			return true;
 		}

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -45,7 +45,8 @@ return [
 					CrawlerProtectionService::CONSTRUCTOR_OPTIONS,
 					$services->getMainConfig()
 				),
-				$services->get( 'CrawlerProtection.ResponseFactory' )
+				$services->get( 'CrawlerProtection.ResponseFactory' ),
+				defined( 'MW_ENTRY_POINT' ) && MW_ENTRY_POINT === 'cli'
 			);
 		},
 ];

--- a/tests/phpunit/unit/CrawlerProtectionServiceTest.php
+++ b/tests/phpunit/unit/CrawlerProtectionServiceTest.php
@@ -46,6 +46,7 @@ class CrawlerProtectionServiceTest extends TestCase {
 	 * @param ResponseFactory|\PHPUnit\Framework\MockObject\MockObject|null $responseFactory
 	 * @param bool $protectRevisions
 	 * @param array $protectedQueryParams
+	 * @param bool $cliMode
 	 * @return CrawlerProtectionService
 	 */
 	private function buildService(
@@ -54,7 +55,8 @@ class CrawlerProtectionServiceTest extends TestCase {
 		$allowedIPs = [],
 		$responseFactory = null,
 		bool $protectRevisions = true,
-		array $protectedQueryParams = [ 'target' ]
+		array $protectedQueryParams = [ 'target' ],
+		bool $cliMode = false
 	): CrawlerProtectionService {
 		$options = new ServiceOptions(
 			CrawlerProtectionService::CONSTRUCTOR_OPTIONS,
@@ -69,7 +71,7 @@ class CrawlerProtectionServiceTest extends TestCase {
 
 		$responseFactory ??= $this->createMock( ResponseFactory::class );
 
-		return new CrawlerProtectionService( $options, $responseFactory );
+		return new CrawlerProtectionService( $options, $responseFactory, $cliMode );
 	}
 
 	// ---------------------------------------------------------------
@@ -571,6 +573,29 @@ class CrawlerProtectionServiceTest extends TestCase {
 		$this->assertFalse( $service->checkPerformAction( $output, $user, $request ) );
 	}
 
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionAllowsProtectedActionOnCommandLine() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, 'history' ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory, true, [ 'target' ], true );
+		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
 	// ---------------------------------------------------------------
 	// isProtectedAction tests
 	// ---------------------------------------------------------------
@@ -753,6 +778,29 @@ class CrawlerProtectionServiceTest extends TestCase {
 			$responseFactory
 		);
 		$this->assertTrue( $service->checkSpecialPage( 'Search', $output, $user ) );
+	}
+
+	/**
+	 * @covers ::checkSpecialPage
+	 */
+	public function testCheckSpecialPageAllowsProtectedPageOnCommandLine() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService(
+			[ 'RecentChangesLinked', 'WhatLinksHere', 'MobileDiff' ],
+			[],
+			[],
+			$responseFactory,
+			true,
+			[ 'target' ],
+			true
+		);
+		$this->assertTrue( $service->checkSpecialPage( 'WhatLinksHere', $output, $user ) );
 	}
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/mywikis/CrawlerProtection/issues/33

CrawlerProtection guards anonymous web requests. On the command line there is no crawler to protect against, and when a maintenance script re-parses a page that transcludes a protected special page, the anonymous-user check fires and denies access. With `$wgCrawlerProtectionRawDenial = true` that denial calls `die()`, terminating the entire maintenance run (`refreshLinks`, `rebuildData`, `runJobs`, etc.).

`ServiceWiring` evaluates `MW_ENTRY_POINT === 'cli'` and injects the result as a `bool $cliMode`, which `checkPerformAction()` and `checkSpecialPage()` return early on. Reading the constant inside the service instead would leave the guard permanently active under PHPUnit, whose bootstrap defines `MW_ENTRY_POINT` as `'cli'`: every existing assertion that a request is blocked would fail, and the new branch could not be covered by any test. Injection also matches core's convention for services that vary by entry point, such as `ChronologyProtector`.

### Verification
On a clean MediaWiki 1.43 install with `$wgCrawlerProtectedSpecialPages = [ 'recentchanges' ]`, `$wgCrawlerProtectionRawDenial = true`, and a page containing `{{Special:RecentChanges}}`:
- Before: `php maintenance/run.php refreshLinks` prints the denial text and terminates (shell exit 0).
- After: it completes both phases (link refresh + illegal-entry cleanup) with no denial.

The unit tests cover both directions: the existing tests build the service with `$cliMode` false, and new tests build it with true and assert that the request is allowed and `ResponseFactory::denyAccess()` is never called.

<sub>AI-authored: Claude Code, `Opus 5`; implemented for @malberts over several rounds, moving from a direct constant read to an injected `$cliMode`; reviewed by @malberts; unit tests run locally with `MW_ENTRY_POINT` unset and set to `cli`, CI not yet run on this branch.</sub>

<details><summary>Production notes</summary>

The `refreshLinks` verification above was performed by an earlier session (`Opus 4.8`) against the original implementation, which read `MW_ENTRY_POINT` inside the service. Runtime behaviour on the command line is unchanged by the move to injection, so it was not repeated. The unit tests and the PHPUnit-bootstrap analysis are from this session (`Opus 5`).

</details>
