### PR TITLE
Protect special-page query parameters sent without a title

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ intensive.
   protecting the history listing page, or vice versa.
 * `$wgCrawlerProtectedQueryParams` - array of special-page query parameters
   that are denied for anonymous users when the request has no `title`
-  parameter (default: `[ 'target' ]`). A request such as
+  parameter, or an empty one (default: `[ 'target' ]`). A request such as
   `index.php?target=Foo&days=365&limit=5000` carries the filter parameters of
   `Special:RecentChangesLinked` but names no special page, so
   `$wgCrawlerProtectedSpecialPages` does not apply to it: MediaWiki ignores

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ intensive.
   anonymous access to those URLs. This setting is independent of
   `$wgCrawlerProtectedActions`, so you can protect revisions/diffs without
   protecting the history listing page, or vice versa.
+* `$wgCrawlerProtectedQueryParams` - array of special-page query parameters
+  that are denied for anonymous users when the request has no `title`
+  parameter (default: `[ 'target' ]`). A request such as
+  `index.php?target=Foo&days=365&limit=5000` carries the filter parameters of
+  `Special:RecentChangesLinked` but names no special page, so
+  `$wgCrawlerProtectedSpecialPages` does not apply to it: MediaWiki ignores
+  the parameters and renders the main page instead. Because each such URL is
+  unique it also defeats CDN and reverse-proxy caching, so every request
+  reaches the application. MediaWiki always emits a `title` alongside these
+  parameters, so their presence without one indicates a crawler-generated
+  request. Set to `[]` to disable this check.
 * `$wgCrawlerProtectionUse418` - drop denied requests in a quick way via
   `die();` with
   [418 I'm a teapot](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/418)

--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,12 @@
             ],
             "merge_strategy": "provide_default"
         },
+        "CrawlerProtectedQueryParams": {
+            "value": [
+                "target"
+            ],
+            "merge_strategy": "provide_default"
+        },
         "CrawlerProtectionRawDenial": {
             "value": false
         },

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
     "name": "CrawlerProtection",
     "author": "[https://mywikis.com MyWikis LLC]",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "url": "https://www.mediawiki.org/wiki/Extension:CrawlerProtection",
     "description": "Suite of protective measures to protect wikis from crawlers.",
     "type": "hook",

--- a/includes/CrawlerProtectionService.php
+++ b/includes/CrawlerProtectionService.php
@@ -42,6 +42,7 @@ class CrawlerProtectionService {
 	/** @var string[] List of constructor options this class accepts */
 	public const CONSTRUCTOR_OPTIONS = [
 		'CrawlerProtectedActions',
+		'CrawlerProtectedQueryParams',
 		'CrawlerProtectedSpecialPages',
 		'CrawlerProtectionAllowedIPs',
 		'CrawlerProtectionProtectRevisions',
@@ -100,6 +101,7 @@ class CrawlerProtectionService {
 
 		if (
 			$this->isProtectedAction( $action )
+			|| $this->hasProtectedQueryParam( $request )
 			|| ( $revisionsProtected && (
 				$type === 'revision'
 				|| $diffId > 0
@@ -111,6 +113,33 @@ class CrawlerProtectionService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Determine whether the request carries a protected special-page query
+	 * parameter without a title naming the special page that consumes it.
+	 *
+	 * Such a request never resolves to a special page, so
+	 * SpecialPageBeforeExecute does not fire and the request is served as an
+	 * ordinary page view. MediaWiki always emits a title alongside these
+	 * parameters, so their presence without one marks the request as
+	 * crawler-generated rather than user-initiated.
+	 *
+	 * @param WebRequest $request
+	 * @return bool
+	 */
+	public function hasProtectedQueryParam( $request ): bool {
+		if ( $request->getVal( 'title' ) !== null ) {
+			return false;
+		}
+
+		foreach ( $this->options->get( 'CrawlerProtectedQueryParams' ) as $param ) {
+			if ( $request->getVal( $param ) !== null ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/CrawlerProtectionService.php
+++ b/includes/CrawlerProtectionService.php
@@ -125,11 +125,16 @@ class CrawlerProtectionService {
 	 * parameters, so their presence without one marks the request as
 	 * crawler-generated rather than user-initiated.
 	 *
+	 * An empty or whitespace-only title (for example "title=") counts as
+	 * missing, since it does not name a special page either and MediaWiki
+	 * renders the main page for it.
+	 *
 	 * @param WebRequest $request
 	 * @return bool
 	 */
 	public function hasProtectedQueryParam( $request ): bool {
-		if ( $request->getVal( 'title' ) !== null ) {
+		$title = $request->getVal( 'title' );
+		if ( $title !== null && trim( $title ) !== '' ) {
 			return false;
 		}
 

--- a/tests/phpunit/unit/CrawlerProtectionServiceTest.php
+++ b/tests/phpunit/unit/CrawlerProtectionServiceTest.php
@@ -45,6 +45,7 @@ class CrawlerProtectionServiceTest extends TestCase {
 	 * @param string|array $allowedIPs
 	 * @param ResponseFactory|\PHPUnit\Framework\MockObject\MockObject|null $responseFactory
 	 * @param bool $protectRevisions
+	 * @param array $protectedQueryParams
 	 * @return CrawlerProtectionService
 	 */
 	private function buildService(
@@ -52,12 +53,14 @@ class CrawlerProtectionServiceTest extends TestCase {
 		array $protectedActions = [ 'history' ],
 		$allowedIPs = [],
 		$responseFactory = null,
-		bool $protectRevisions = true
+		bool $protectRevisions = true,
+		array $protectedQueryParams = [ 'target' ]
 	): CrawlerProtectionService {
 		$options = new ServiceOptions(
 			CrawlerProtectionService::CONSTRUCTOR_OPTIONS,
 			[
 				'CrawlerProtectedActions' => $protectedActions,
+				'CrawlerProtectedQueryParams' => $protectedQueryParams,
 				'CrawlerProtectedSpecialPages' => $protectedPages,
 				'CrawlerProtectionAllowedIPs' => $allowedIPs,
 				'CrawlerProtectionProtectRevisions' => $protectRevisions,
@@ -181,6 +184,106 @@ class CrawlerProtectionServiceTest extends TestCase {
 		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
 
 		$service = $this->buildService( [], [ 'history' ], [], $responseFactory );
+		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionBlocksProtectedQueryParamWithoutTitle() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, null ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->once() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory );
+		$this->assertFalse( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionAllowsProtectedQueryParamWithTitle() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, 'Special:RecentChangesLinked' ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory );
+		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionAllowsUnconfiguredQueryParam() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, null ],
+			[ 'curid', null, '1234' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory );
+		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionAllowsProtectedQueryParamWhenListEmpty() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, null ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory, true, [] );
 		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
 	}
 
@@ -427,6 +530,52 @@ class CrawlerProtectionServiceTest extends TestCase {
 		$this->assertTrue( $service->isProtectedAction( 'history' ) );
 		$this->assertTrue( $service->isProtectedAction( 'HISTORY' ) );
 		$this->assertTrue( $service->isProtectedAction( 'History' ) );
+	}
+
+	// ---------------------------------------------------------------
+	// hasProtectedQueryParam tests
+	// ---------------------------------------------------------------
+
+	/**
+	 * @covers ::hasProtectedQueryParam
+	 */
+	public function testHasProtectedQueryParamReturnsTrueWithoutTitle() {
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'title', null, null ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$service = $this->buildService();
+		$this->assertTrue( $service->hasProtectedQueryParam( $request ) );
+	}
+
+	/**
+	 * @covers ::hasProtectedQueryParam
+	 */
+	public function testHasProtectedQueryParamReturnsFalseWithTitle() {
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'title', null, 'Special:RecentChangesLinked' ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$service = $this->buildService();
+		$this->assertFalse( $service->hasProtectedQueryParam( $request ) );
+	}
+
+	/**
+	 * @covers ::hasProtectedQueryParam
+	 */
+	public function testHasProtectedQueryParamReturnsFalseForUnconfiguredParam() {
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'title', null, null ],
+			[ 'curid', null, '1234' ],
+		] );
+
+		$service = $this->buildService();
+		$this->assertFalse( $service->hasProtectedQueryParam( $request ) );
 	}
 
 	// ---------------------------------------------------------------

--- a/tests/phpunit/unit/CrawlerProtectionServiceTest.php
+++ b/tests/phpunit/unit/CrawlerProtectionServiceTest.php
@@ -240,6 +240,85 @@ class CrawlerProtectionServiceTest extends TestCase {
 	/**
 	 * @covers ::checkPerformAction
 	 */
+	public function testCheckPerformActionBlocksProtectedQueryParamWithEmptyTitle() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, '' ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->once() )->method( 'denyAccess' );
+
+		$service = $this->buildService( [], [ 'history' ], [], $responseFactory );
+		$this->assertFalse( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionBlocksProtectedQueryParamFromCustomList() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, null ],
+			[ 'feedformat', null, 'atom' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->once() )->method( 'denyAccess' );
+
+		$service = $this->buildService(
+			[], [ 'history' ], [], $responseFactory, true, [ 'feedformat', 'curid' ]
+		);
+		$this->assertFalse( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
+	public function testCheckPerformActionAllowsDefaultParamWhenNotInCustomList() {
+		$output = $this->createMock( self::$outputPageClassName );
+		$user = $this->createMock( self::$userClassName );
+		$user->method( 'isRegistered' )->willReturn( false );
+
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'type', null, null ],
+			[ 'action', null, null ],
+			[ 'diff', null, null ],
+			[ 'oldid', null, null ],
+			[ 'title', null, null ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$responseFactory = $this->createMock( ResponseFactory::class );
+		$responseFactory->expects( $this->never() )->method( 'denyAccess' );
+
+		$service = $this->buildService(
+			[], [ 'history' ], [], $responseFactory, true, [ 'feedformat', 'curid' ]
+		);
+		$this->assertTrue( $service->checkPerformAction( $output, $user, $request ) );
+	}
+
+	/**
+	 * @covers ::checkPerformAction
+	 */
 	public function testCheckPerformActionAllowsUnconfiguredQueryParam() {
 		$output = $this->createMock( self::$outputPageClassName );
 		$user = $this->createMock( self::$userClassName );
@@ -543,6 +622,34 @@ class CrawlerProtectionServiceTest extends TestCase {
 		$request = $this->createMock( self::$webRequestClassName );
 		$request->method( 'getVal' )->willReturnMap( [
 			[ 'title', null, null ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$service = $this->buildService();
+		$this->assertTrue( $service->hasProtectedQueryParam( $request ) );
+	}
+
+	/**
+	 * @covers ::hasProtectedQueryParam
+	 */
+	public function testHasProtectedQueryParamTreatsEmptyTitleAsMissing() {
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'title', null, '' ],
+			[ 'target', null, 'Project:Some_Page' ],
+		] );
+
+		$service = $this->buildService();
+		$this->assertTrue( $service->hasProtectedQueryParam( $request ) );
+	}
+
+	/**
+	 * @covers ::hasProtectedQueryParam
+	 */
+	public function testHasProtectedQueryParamTreatsWhitespaceTitleAsMissing() {
+		$request = $this->createMock( self::$webRequestClassName );
+		$request->method( 'getVal' )->willReturnMap( [
+			[ 'title', null, '   ' ],
 			[ 'target', null, 'Project:Some_Page' ],
 		] );
 


### PR DESCRIPTION
Fixes #35.

Special-page filter parameters sent to `index.php` without a `title` parameter never resolve to a special page, so `SpecialPageBeforeExecute` does not fire and `$wgCrawlerProtectedSpecialPages` does not apply. MediaWiki ignores the parameters and renders the main page instead, and because each such URL is unique (the `from=` timestamp is arbitrary) it also defeats CDN and reverse-proxy caching, so every request reaches the application. See #35 for the traffic we observed and the measurements.

## Change

Adds `$wgCrawlerProtectedQueryParams`, checked in `checkPerformAction()` for anonymous users when no `title` parameter is present:

```php
public function hasProtectedQueryParam( $request ): bool {
    if ( $request->getVal( 'title' ) !== null ) {
        return false;
    }

    foreach ( $this->options->get( 'CrawlerProtectedQueryParams' ) as $param ) {
        if ( $request->getVal( $param ) !== null ) {
            return true;
        }
    }

    return false;
}
```

The default is `[ 'target' ]` — it covers `RecentChangesLinked` and `WhatLinksHere` (two of the three shipped `$wgCrawlerProtectedSpecialPages` defaults) and is meaningless in core without a `title` naming the special page that consumes it. `[]` disables the check. Happy to change the default to `[]` if you'd rather this were strictly opt-in.

Existing behavior is unchanged for registered users and allowed IP ranges, since `checkPerformAction()` returns early for both before this check runs.

## Notes

- `getVal()` is used rather than `getCheck()` for consistency with the surrounding code and the existing test mocks.
- Tests: four `checkPerformAction` cases (blocked without title, allowed with title, allowed for an unconfigured parameter, allowed when the list is empty) and three direct `hasProtectedQueryParam` cases.
- README documents the new setting alongside the existing ones.

## Verification

Run locally in Docker:

- `composer phpunit` — **72/72 pass** (1 pre-existing skip) on MediaWiki 1.43 / PHP 8.2, including the seven new tests.
- `phpcs` — **9/9 clean** against `mediawiki-codesniffer 43.0.0` on PHP 8.3.

Three unrelated snags I hit while setting that up, in case they're useful (happy to file separately rather than clutter this PR):

1. `.gitmodules` declares the `build` submodule but the gitlink isn't committed to the tree, so `git submodule update --init` is a no-op on a fresh clone and `make ci` can't self-bootstrap. I cloned `docker-compose-ci` into `build/` by hand.
2. `make ci` exits 0 without running anything: `composer-test` in `build/Makefile` is guarded by `ifdef COMPOSER_EXT`, and this repo's Makefile sets `COMPOSER_EXT?=` (empty), so `ifdef` is false. `COMPOSER_EXT=true make composer-test` does run the checks.
3. In-container `composer phpcs` aborts at ruleset-load time with `Referenced sniff "Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence" does not exist` — a codesniffer version mismatch inside the MW image, independent of any source change. Running phpcs against the extension's own `vendor/` works fine.
